### PR TITLE
Changed Russian Revolver spawn on Pubbystation to spawner that has 50…

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -21083,7 +21083,7 @@
 /area/crew_quarters/bar)
 "bco" = (
 /obj/structure/table/wood/fancy,
-/obj/item/gun/ballistic/revolver/russian{
+/obj/effect/spawner/lootdrop/russian_revolver{
 	pixel_y = 16
 	},
 /obj/item/storage/box/matches{

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -368,4 +368,9 @@
 				/obj/item/dice/fourdd6 = 1,
 				/obj/item/dice/d100 = 1
 				)
-
+/obj/effect/spawner/lootdrop/russian_revolver
+	name = "normal or cursed russian revolver spawner"
+	loot = list(
+				/obj/item/gun/ballistic/revolver/russian = 1,
+				/obj/item/gun/ballistic/revolver/russian/soul = 1
+				)


### PR DESCRIPTION
…/50 chance to spawn either Russian Revolver or Cursed Russian Revolver

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This changes the Russian Revolver spawn in the bar on Pubbystation into a spawner with a loot table of two items, one will be chosen at random:

Russian Revolver
Cursed Russian Revolver (when somebody is killed by it, drops a soul stone)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds some spice to the round by giving a chance to have a regular soul stone (usable by anybody) to play with, if somebody happens to kill themselves while playing russian roulette.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
**ADD:** New loot table containing the Russian Revolver and Cursed Russian Revolver to code/game/objects/effects/spawners/lootdrop.dm
**CHANGED:** The item spawn to a item spawner in the map .dmm file _maps/map_files/PubbyStation/PubbyStation.dmm 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
