### PR TITLE
Fixed 3 missing textures and 6 incorrectly rotated decals on away mission map undergroundoutpost45.dmm

### DIFF
--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -25,6 +25,20 @@
 "ag" = (
 /turf/closed/wall/mineral/titanium,
 /area/awaymission/undergroundoutpost45/central)
+"ah" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/awaymission/undergroundoutpost45/caves)
+"ai" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/awaymission/undergroundoutpost45/caves)
 "aj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel{
@@ -131,6 +145,13 @@
 	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/central)
+"av" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/awaymission/undergroundoutpost45/caves)
 "ax" = (
 /obj/effect/landmark/awaystart,
 /turf/open/floor/plasteel{
@@ -2091,15 +2112,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/awaymission/undergroundoutpost45/central)
-"eu" = (
-/turf/open/floor/plating{
-	heat_capacity = 1e+006;
-	icon_plating = "asteroidplating";
-	icon_state = "asteroidplating";
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	temperature = 363.9
-	},
-/area/awaymission/undergroundoutpost45/caves)
 "ev" = (
 /obj/item/clothing/under/misc/pj,
 /obj/structure/closet/secure_closet/personal/cabinet{
@@ -13271,13 +13283,6 @@
 	name = "Cave Floor";
 	temperature = 363.9
 	},
-/area/awaymission/undergroundoutpost45/caves)
-"DJ" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 6
-	},
-/turf/open/floor/plating/airless,
 /area/awaymission/undergroundoutpost45/caves)
 "KE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -41969,7 +41974,7 @@ tT
 gy
 uN
 hH
-eu
+UM
 eJ
 ad
 ad
@@ -42226,7 +42231,7 @@ tU
 uw
 uO
 vk
-eu
+OF
 eJ
 eJ
 ad
@@ -42483,7 +42488,7 @@ tV
 ux
 uP
 hH
-eu
+av
 eJ
 eJ
 eJ
@@ -48668,7 +48673,7 @@ xY
 yb
 ye
 ww
-DJ
+av
 eJ
 eJ
 eJ
@@ -50669,9 +50674,9 @@ ad
 ad
 ad
 ad
-eu
-eu
-eu
+ah
+ai
+av
 fn
 eJ
 eJ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes 3 missing textures and 6 decals that were rotated the wrong way on away mission map undergroundoutpost45.dmm.

The diff is going to look super spooky because when you reconvert the map after saving it with DreamMaker to the format used in tgstation code with the tools provided in  /tgstation/tools/mapmerge2/  it randomizes the element names in the matrix.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Missing textures are ugly and the caution stripes on the floor outside the airlocks were rotated incorrectly. It's nice to have pretty things that look the way they are supposed to.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
**fix:** Fixed 3 missing textures outside the bottom left most airlock landing
**fix:** Fixed incorrect rotation of 6 caution stripe decals on every airlock landing except for bottom right most airlock.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
