### PR TITLE
Partially fixed welding tools not warning you that you are wasting fu…

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -139,9 +139,8 @@
 			if(L.IgniteMob())
 				message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(L)] on fire with [src] at [AREACOORD(user)]")
 				log_game("[key_name(user)] set [key_name(L)] on fire with [src] at [AREACOORD(user)]")
-		else
-			if(!isobj(O))
-				to_chat(user, "<span class='warning'>[src] has no effect, you've wasted some fuel!</span>")
+		else if((!O.welder_act() && !isobj(O)) || (!O.welder_act() && isitem(O)))
+			to_chat(user, "<span class='warning'>[src] has no effect, you've wasted some fuel!</span>")
 
 /obj/item/weldingtool/attack_self(mob/user)
 	if(src.reagents.has_reagent(/datum/reagent/toxin/plasma))

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -139,7 +139,9 @@
 			if(L.IgniteMob())
 				message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(L)] on fire with [src] at [AREACOORD(user)]")
 				log_game("[key_name(user)] set [key_name(L)] on fire with [src] at [AREACOORD(user)]")
-
+		else
+			if(!isobj(O))
+				to_chat(user, "<span class='warning'>[src] has no effect, you've wasted some fuel!</span>")
 
 /obj/item/weldingtool/attack_self(mob/user)
 	if(src.reagents.has_reagent(/datum/reagent/toxin/plasma))


### PR DESCRIPTION
…el if there is no weld action available. Still needs work, structures that are fully repaired will still use up fuel but wont warn you

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This fixes the welding tools not warning you that you are wasting fuel by using them on objects that do have any welding actions.

It's still not 100% fixed since, detecting by if something is an object or not works for things that have no action with the welding tool but it still doesn't warn you if you try to weld something like a window that has welding actions but is at full integrity (It tells you that it doesn't need to be repaired but still wastes fuel and doesn't warn you).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Informs unaware players that they are using up their welder fuel when they spam click something that cannot be welded, but still lets them make the mistake.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
**add:** Added new warning message for welding un-weldable things "[Welding tool name] has no effect, you've wasted some fuel!"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
