### PR TITLE
tesla ram damage nerf

### DIFF
--- a/code/modules/vehicles/cars/tesla.dm
+++ b/code/modules/vehicles/cars/tesla.dm
@@ -42,7 +42,7 @@
 			var/mob/living/carbon/human/H = M
 			H.Paralyze(100)
 			H.adjustStaminaLoss(30)
-			H.apply_damage(rand(20,35), BRUTE)
+			H.apply_damage(rand(10,25), BRUTE)
 			if(!crash_all)
 				H.throw_at(throw_target, 4, 3)
 				visible_message("<span class='danger'>[src] crashes into [H]!</span>")


### PR DESCRIPTION
Make it less busted

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces damage when ramming another player from between 20 - 35 to 10 - 25

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
damage was busted, makes it less OP
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: reduced tesla damage when ramming other players
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
